### PR TITLE
Return latest version as JSON for /latest with Accept: application/json

### DIFF
--- a/src/main/scala/Web.scala
+++ b/src/main/scala/Web.scala
@@ -101,15 +101,27 @@ object Web:
             ZIO.succeed:
               Response.notFound(groupArtifactVersion.toPath.toString)
     else if request.header(Accept).exists(_.mimeTypes.exists(_.mediaType.matches(MediaType.application.json))) then
-      Handler.fromResponseZIO:
-        defer:
-          val contents = Extractor.javadocContents(groupArtifactVersion).run
-          import zio.json.*
-          Response.json(contents.toJson)
-        .catchAll:
-          case _: MavenCentral.NotFoundError | _: JarCache.UpstreamCorruptError =>
+      if groupArtifactVersion.version == MavenCentral.Version.latest then
+        // For `/{g}/{a}/latest` with `Accept: application/json`, return just the
+        // resolved latest version as JSON (e.g. `{"version":"4.0.0"}`) rather
+        // than redirecting / listing symbols.
+        Handler.fromResponseZIO:
+          ZIO.serviceWithZIO[Extractor.LatestCache](_.cache.get(groupArtifactVersion.noVersion)).map: latest =>
+            import zio.json.*
+            Response.json(Map("version" -> latest.toString).toJson)
+          .catchAll: _ =>
             ZIO.succeed:
-              Response.notFound(groupArtifactVersion.toPath.toString)
+              Response.notFound(groupArtifactVersion.noVersion.toPath.toString)
+      else
+        Handler.fromResponseZIO:
+          defer:
+            val contents = Extractor.javadocContents(groupArtifactVersion).run
+            import zio.json.*
+            Response.json(contents.toJson)
+          .catchAll:
+            case _: MavenCentral.NotFoundError | _: JarCache.UpstreamCorruptError =>
+              ZIO.succeed:
+                Response.notFound(groupArtifactVersion.toPath.toString)
     else
       Handler.fromZIO:
         if groupArtifactVersion.version == MavenCentral.Version.latest then

--- a/src/test/scala/AppSpec.scala
+++ b/src/test/scala/AppSpec.scala
@@ -179,6 +179,20 @@ object AppSpec extends ZIOSpecDefault:
           locationNF.contains("&color=red"),
           notFound.header(Header.CacheControl).exists(_.renderedValue.contains("max-age=300")),
         )
+    , test("latest with Accept: application/json returns just the latest version"):
+      val forwardedForHeader = Header.Custom("X-Forwarded-For", "192.168.1.100")
+      defer:
+        val resp = Web.appWithMiddleware.runZIO(
+          Request.get(URL(Path.root / "org.webjars" / "jquery" / "latest"))
+            .addHeader(forwardedForHeader)
+            .addHeader(Header.Accept(MediaType.application.json))
+        ).run
+        val body = resp.body.asString.run
+        assertTrue(
+          resp.status.isSuccess,
+          resp.header(Header.ContentType).exists(_.mediaType.matches(MediaType.application.json)),
+          body == """{"version":"4.0.0"}""",
+        )
     , test("rate limit bad actors"):
       defer:
         val forwardedBadActorHeader = Header.Custom("X-Forwarded-For", "192.168.1.100")


### PR DESCRIPTION
## Summary

A request to `/{groupId}/{artifactId}/latest` with `Accept: application/json` now returns just the resolved latest version as JSON, instead of attempting to list symbols for the unresolved `"latest"` version.

```
GET /dev.zio/zio-http-cli_3/latest
Accept: application/json
→ 200 {"version":"3.6.0"}
```

## Changes

- **`src/main/scala/Web.scala`** — In the `withVersion` handler's `application/json` branch, special-case `latest`: resolve the actual latest version via the existing `LatestCache` (the same path the HTML redirect branch already uses) and return `{"version":"<latest>"}`. Non-`latest` JSON requests still return the full symbol list as before; failures return 404.
- **`src/test/scala/AppSpec.scala`** — Added a test asserting `/org.webjars/jquery/latest` with `Accept: application/json` returns `200`, `Content-Type: application/json`, and body `{"version":"4.0.0"}` (consistent with the existing routing test that pins jquery's latest to `4.0.0`).

## Note on verification

This couldn't be compiled/tested locally — the project's `build.sbt` hard-requires JDK 25 but the working environment only had JDK 21. CI runs on JDK 25, so the change will compile and the test will run there. The change closely mirrors the existing `latest`-resolution code in the same method.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01J8cHkgusCTp9mjc4WPkmRa)_